### PR TITLE
Pretty-print

### DIFF
--- a/Curve.cabal
+++ b/Curve.cabal
@@ -17,6 +17,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Curve
   build-depends:       base >= 4.7 && < 5
+                     , containers
                      , transformers
   default-language:    Haskell2010
   ghc-options:         -Wall -fno-warn-name-shadowing -threaded -rtsopts -with-rtsopts=-N

--- a/Curve.cabal
+++ b/Curve.cabal
@@ -27,6 +27,7 @@ test-suite Curve-test
   hs-source-dirs:      test
   main-is:             Spec.hs
   build-depends:       base
+                     , containers
                      , Curve
                      , hspec
                      , QuickCheck

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -85,14 +85,15 @@ instance Eq1 Expression where
   eq1 = (==)
 
 instance Show Term' where
-  showsPrec n term rest = case out term of
-    Variable name -> showsPrec n name rest
-    Type -> "Type" ++ rest
-    Implicit -> "Implicit" ++ rest
-    Application a b -> showsPrec 10 a " " ++ showsPrec 10 b rest
-    Lambda i t body | Set.member (Local i) (freeVariables body) -> "λ " ++ shows (Local i) " : " ++ shows t " . " ++ shows body rest
-    Lambda _ t body -> "λ _ : " ++ shows t " . " ++ shows body rest
-    -- Lambda _ t body = shows t " → " ++ body
+  showsPrec n term rest = wrap $ case out term of
+    Variable name -> (show name, 11)
+    Type -> ("Type", 11)
+    Implicit -> ("Implicit", 11)
+    Application a b -> (showsPrec 10 a " " ++ showsPrec 11 b "", 10)
+    Lambda i t body | Set.member (Local i) (freeVariables body) -> ("λ " ++ shows (Local i) " : " ++ shows t " . " ++ show body, 0)
+    Lambda _ t body -> ("λ _ : " ++ shows t " . " ++ show body, 0)
+    -- Lambda _ t body -> (shows t " → " ++ body, 0)
+    where wrap (string, m) = showParen (m < n) (showString string) rest
 
 
 instance Eq1 f => Eq (Term f) where

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -73,6 +73,8 @@ freeVariables = cata inExpression
           _ -> mempty
 
 
+-- Recursion schemes
+
 cata :: Functor f => (f a -> a) -> Term f -> a
 cata f = f . fmap (cata f) . out
 

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -2,6 +2,7 @@
 module Curve where
 
 import Data.Functor.Classes
+import qualified Data.Set as Set
 
 data Name
   = Local Int
@@ -61,6 +62,14 @@ unify expected actual = case (out expected, out actual) of
   (Lambda i1 a1 b1, Lambda i2 a2 b2) | i1 == i2 -> Unification $ Lambda i2 (unify a1 a2) (unify b1 b2)
 
   _ -> Conflict expected actual
+
+
+freeVariables :: Term' -> Set.Set Name
+freeVariables = cata inExpression
+  where inExpression expression = case expression of
+          Variable name -> Set.singleton name
+          Lambda i t b -> Set.delete (Local i) b `Set.union` t
+          Application a b -> a `Set.union` b
 
 
 cata :: Functor f => (f a -> a) -> Term f -> a

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -6,7 +6,7 @@ import Data.Functor.Classes
 data Name
   = Local Int
   | Global String
-  deriving (Show, Eq)
+  deriving (Show, Eq, Ord)
 
 data Expression term
   = Type

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -85,10 +85,10 @@ instance Eq1 Expression where
   eq1 = (==)
 
 instance Show Term' where
-  showsPrec = showsLevel False
+  showsPrec = showsLevelPrec False
 
-showsLevel :: Bool -> Int -> Term' -> ShowS
-showsLevel isType n term = case out term of
+showsLevelPrec :: Bool -> Int -> Term' -> ShowS
+showsLevelPrec isType n term = case out term of
   Variable name -> shows name
   Type -> showString "Type"
   Implicit -> showString "Implicit"

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -94,8 +94,9 @@ showsLevel isType n term = case out term of
   Implicit -> showString "Implicit"
   Application a b -> showParen (n > 10) (showsPrec 10 a . showString " " . showsPrec 11 b)
   Lambda i t body | Set.member (Local i) (freeVariables body) -> showString "λ " . shows (Local i) . showString " : " . shows t  . showString " . " . shows body
-  Lambda _ t body -> showString "λ _ : " . shows t  . showString " . " . shows body
-  -- Lambda _ t body -> (shows t " → " ++ body, 0)
+  Lambda _ t body -> if isType
+    then shows t . showString " → " . shows body
+    else showString "λ _ : " . shows t  . showString " . " . shows body
 
 instance Eq1 f => Eq (Term f) where
   a == b = out a `eq1` out b

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -85,15 +85,14 @@ instance Eq1 Expression where
   eq1 = (==)
 
 instance Show Term' where
-  showsPrec n term rest = wrap $ case out term of
-    Variable name -> (show name, 11)
-    Type -> ("Type", 11)
-    Implicit -> ("Implicit", 11)
-    Application a b -> (showsPrec 10 a " " ++ showsPrec 11 b "", 10)
-    Lambda i t body | Set.member (Local i) (freeVariables body) -> ("λ " ++ shows (Local i) " : " ++ shows t " . " ++ show body, 0)
-    Lambda _ t body -> ("λ _ : " ++ shows t " . " ++ show body, 0)
+  showsPrec n term = case out term of
+    Variable name -> shows name
+    Type -> showString "Type"
+    Implicit -> showString "Implicit"
+    Application a b -> showParen (n > 10) (showsPrec 10 a . showString " " . showsPrec 11 b)
+    Lambda i t body | Set.member (Local i) (freeVariables body) -> showString "λ " . shows (Local i) . showString " : " . shows t  . showString " . " . shows body
+    Lambda _ t body -> showString "λ _ : " . shows t  . showString " . " . shows body
     -- Lambda _ t body -> (shows t " → " ++ body, 0)
-    where wrap (string, m) = showParen (m < n) (showString string) rest
 
 
 instance Eq1 f => Eq (Term f) where

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -98,6 +98,9 @@ showsLevelPrec isType n term = case out term of
     then shows t . showString " → " . shows body
     else showString "λ _ : " . shows t  . showString " . " . shows body
 
+showsLevel :: Bool -> Term' -> ShowS
+showsLevel level = showsLevelPrec level 0
+
 instance Eq1 f => Eq (Term f) where
   a == b = out a `eq1` out b
 

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -2,6 +2,7 @@
 module Curve where
 
 import Data.Functor.Classes
+import qualified Data.List as List
 import qualified Data.Set as Set
 
 data Name
@@ -81,6 +82,20 @@ cata f = f . fmap (cata f) . out
 para :: Functor f => (f (Term f, a) -> a) -> Term f -> a
 para f = f . fmap fanout . out
   where fanout a = (a, para f a)
+
+
+-- Numerals
+
+digits :: Integral a => a -> a -> [a]
+digits base i = fst $ foldr nextDigit ([], i) (replicate (fromIntegral $ countDigits base i) ())
+  where nextDigit _ (list, prev) | (next, remainder) <- prev `divMod` base = (remainder : list, next)
+
+countDigits :: Integral a => a -> a -> a
+countDigits base i = 1 + floor (logBase (fromIntegral base) (fromIntegral $ abs i) :: Double)
+
+showNumeral :: Integral i => String -> i -> String
+showNumeral "" _ = ""
+showNumeral alphabet i = List.genericIndex alphabet <$> digits (List.genericLength alphabet) i
 
 
 -- Instances

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -85,17 +85,17 @@ instance Eq1 Expression where
   eq1 = (==)
 
 instance Show Term' where
-  showsPrec n term = case out term of
-    Variable name -> shows name
-    Type -> showString "Type"
-    Implicit -> showString "Implicit"
-    Application a b -> showParen (n > 10) (showsPrec 10 a . showString " " . showsPrec 11 b)
-    Lambda i t body | Set.member (Local i) (freeVariables body) -> showString "λ " . shows (Local i) . showString " : " . shows t  . showString " . " . shows body
-    Lambda _ t body -> showString "λ _ : " . shows t  . showString " . " . shows body
-    -- Lambda _ t body -> (shows t " → " ++ body, 0)
+  showsPrec = showLevel False
 
-showLevel :: Bool -> Term' -> ShowS
-showLevel = const . shows
+showsLevel :: Bool -> Int -> Term' -> ShowS
+showsLevel isType n term = case out term of
+  Variable name -> shows name
+  Type -> showString "Type"
+  Implicit -> showString "Implicit"
+  Application a b -> showParen (n > 10) (showsPrec 10 a . showString " " . showsPrec 11 b)
+  Lambda i t body | Set.member (Local i) (freeVariables body) -> showString "λ " . shows (Local i) . showString " : " . shows t  . showString " . " . shows body
+  Lambda _ t body -> showString "λ _ : " . shows t  . showString " . " . shows body
+  -- Lambda _ t body -> (shows t " → " ++ body, 0)
 
 instance Eq1 f => Eq (Term f) where
   a == b = out a `eq1` out b

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -93,7 +93,7 @@ showsLevelPrec isType n term = case out term of
   Type -> showString "Type"
   Implicit -> showString "Implicit"
   Application a b -> showParen (n > 10) (showsLevelPrec isType 10 a . showString " " . showsLevelPrec isType 11 b)
-  Lambda i t body | Set.member (Local i) (freeVariables body) -> showString "λ " . shows (Local i) . showString " : " . shows t  . showString " . " . shows body
+  Lambda i t body | Set.member (Local i) (freeVariables body) -> showString "λ " . shows (Local i) . showString " : " . showsLevel isType t  . showString " . " . showsLevel isType body
   Lambda _ t body -> if isType
     then showsLevel isType t . showString " → " . showsLevel isType body
     else showString "λ _ : " . showsLevel isType t  . showString " . " . showsLevel isType body

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -81,6 +81,8 @@ para f = f . fmap fanout . out
   where fanout a = (a, para f a)
 
 
+-- Instances
+
 instance Eq1 Expression where
   eq1 = (==)
 

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -91,7 +91,7 @@ showsLevelPrec :: Bool -> Int -> Term' -> ShowS
 showsLevelPrec isType n term = case out term of
   Variable name -> shows name
   Type -> showString "Type"
-  Implicit -> showString "Implicit"
+  Implicit -> showString "_"
   Application a b -> showParen (n > prec) (showsLevelPrec isType prec a . showString " " . showsLevelPrec isType (prec + 1) b)
     where prec = 10
   Lambda i t body | Set.member (Local i) (freeVariables body) -> showString "λ " . shows (Local i) . showString " : " . showsLevel isType t  . showString " . " . showsLevel isType body

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -127,9 +127,6 @@ showsLevelPrec isType n term = case out term of
 showsLevel :: Bool -> Term' -> ShowS
 showsLevel level = showsLevelPrec level 0
 
-showsTerm :: Term' -> ShowS
-showsTerm = showsLevel False
-
 showsType :: Term' -> ShowS
 showsType = showsLevel True
 

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -95,7 +95,7 @@ showsLevelPrec isType n term = case out term of
   Application a b -> showParen (n > prec) (showsLevelPrec isType prec a . showString " " . showsLevelPrec isType (prec + 1) b)
     where prec = 10
   Lambda i t body | Set.member (Local i) (freeVariables body) -> showString "λ " . shows (Local i) . showString " : " . showsLevel isType t  . showString " . " . showsLevel isType body
-  Lambda _ t body -> if isType
+  Lambda _ t body -> showParen (n > 0) $ if isType
     then showsLevelPrec isType 1 t . showString " → " . showsLevel isType body
     else showString "λ _ : " . showsLevel isType t  . showString " . " . showsLevel isType body
 

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -94,10 +94,10 @@ showsLevelPrec isType n term = case out term of
   Implicit -> showString "_"
   Application a b -> showParen (n > prec) (showsLevelPrec isType prec a . showString " " . showsLevelPrec isType (prec + 1) b)
     where prec = 10
-  Lambda i t body | Set.member (Local i) (freeVariables body) -> showString "λ " . shows (Local i) . showString " : " . showsLevel isType t  . showString " . " . showsLevel isType body
+  Lambda i t body | Set.member (Local i) (freeVariables body) -> showString "λ " . shows (Local i) . showString " : " . showsLevel True t  . showString " . " . showsLevel isType body
   Lambda _ t body -> showParen (n > 0) $ if isType
-    then showsLevelPrec isType 1 t . showString " → " . showsLevel isType body
-    else showString "λ _ : " . showsLevel isType t  . showString " . " . showsLevel isType body
+    then showsLevelPrec True 1 t . showString " → " . showsLevel True body
+    else showString "λ _ : " . showsLevel True t  . showString " . " . showsLevel isType body
 
 showsLevel :: Bool -> Term' -> ShowS
 showsLevel level = showsLevelPrec level 0

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -63,6 +63,10 @@ unify expected actual = case (out expected, out actual) of
   _ -> Conflict expected actual
 
 
+cata :: Functor f => (f a -> a) -> Term f -> a
+cata f = f . fmap (cata f) . out
+
+
 instance Eq1 Expression where
   eq1 = (==)
 

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -85,19 +85,14 @@ instance Eq1 Expression where
   eq1 = (==)
 
 instance Show Term' where
-  showsPrec precedence term = (para showTerm term ++)
-    where showTerm expression = case expression of
-            Variable n -> show n
-
-            Type -> "Type"
-
-            Application (_, a) (_, b) -> a ++ " " ++ b
-
-            Lambda i (_, t) (body, bodyString) | Set.member (Local i) (freeVariables body) -> "λ " ++ show (Local i) ++ " : " ++ t ++ " . " ++ bodyString
-            Lambda _ (_, t) (_, body) -> "λ _ : " ++ t ++ " . " ++ body
-            -- Lambda _ t body -> t ++ " → " ++ body
-
-            Implicit -> "_"
+  showsPrec n term rest = case out term of
+    Variable name -> showsPrec n name rest
+    Type -> "Type" ++ rest
+    Implicit -> "Implicit" ++ rest
+    Application a b -> showsPrec 10 a " " ++ showsPrec 10 b rest
+    Lambda i t body | Set.member (Local i) (freeVariables body) -> "λ " ++ shows (Local i) " : " ++ shows t " . " ++ shows body rest
+    Lambda _ t body -> "λ _ : " ++ shows t " . " ++ shows body rest
+    -- Lambda _ t body = shows t " → " ++ body
 
 
 instance Eq1 f => Eq (Term f) where

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -96,7 +96,7 @@ showsLevelPrec isType n term = case out term of
     where prec = 10
   Lambda i t body | Set.member (Local i) (freeVariables body) -> showString "λ " . shows (Local i) . showString " : " . showsLevel isType t  . showString " . " . showsLevel isType body
   Lambda _ t body -> if isType
-    then showsLevel isType t . showString " → " . showsLevel isType body
+    then showsLevelPrec isType 1 t . showString " → " . showsLevel isType body
     else showString "λ _ : " . showsLevel isType t  . showString " . " . showsLevel isType body
 
 showsLevel :: Bool -> Term' -> ShowS

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -85,7 +85,7 @@ instance Eq1 Expression where
   eq1 = (==)
 
 instance Show Term' where
-  showsPrec = showLevel False
+  showsPrec = showsLevel False
 
 showsLevel :: Bool -> Int -> Term' -> ShowS
 showsLevel isType n term = case out term of

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -70,6 +70,7 @@ freeVariables = cata inExpression
           Variable name -> Set.singleton name
           Lambda i t b -> Set.delete (Local i) b `Set.union` t
           Application a b -> a `Set.union` b
+          _ -> mempty
 
 
 cata :: Functor f => (f a -> a) -> Term f -> a

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -92,7 +92,8 @@ showsLevelPrec isType n term = case out term of
   Variable name -> shows name
   Type -> showString "Type"
   Implicit -> showString "Implicit"
-  Application a b -> showParen (n > 10) (showsLevelPrec isType 10 a . showString " " . showsLevelPrec isType 11 b)
+  Application a b -> showParen (n > prec) (showsLevelPrec isType prec a . showString " " . showsLevelPrec isType (prec + 1) b)
+    where prec = 10
   Lambda i t body | Set.member (Local i) (freeVariables body) -> showString "λ " . shows (Local i) . showString " : " . showsLevel isType t  . showString " . " . showsLevel isType body
   Lambda _ t body -> if isType
     then showsLevel isType t . showString " → " . showsLevel isType body

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -66,6 +66,10 @@ unify expected actual = case (out expected, out actual) of
 cata :: Functor f => (f a -> a) -> Term f -> a
 cata f = f . fmap (cata f) . out
 
+para :: Functor f => (f (Term f, a) -> a) -> Term f -> a
+para f = f . fmap fanout . out
+  where fanout a = (a, para f a)
+
 
 instance Eq1 Expression where
   eq1 = (==)

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -94,7 +94,9 @@ showsLevelPrec isType n term = case out term of
   Implicit -> showString "_"
   Application a b -> showParen (n > prec) (showsLevelPrec isType prec a . showString " " . showsLevelPrec isType (prec + 1) b)
     where prec = 10
-  Lambda i t body | Set.member (Local i) (freeVariables body) -> showString "λ " . shows (Local i) . showString " : " . showsLevel True t  . showString " . " . showsLevel isType body
+  Lambda i t body | Set.member (Local i) (freeVariables body) -> if isType
+    then showString "(" . shows (Local i) . showString " : " . showsLevel True t . showString ") → " . showsLevel True body
+    else showString "λ " . shows (Local i) . showString " : " . showsLevel True t  . showString " . " . showsLevel isType body
   Lambda _ t body -> showParen (n > 0) $ if isType
     then showsLevelPrec True 1 t . showString " → " . showsLevel True body
     else showString "λ _ : " . showsLevel True t  . showString " . " . showsLevel isType body

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -127,6 +127,12 @@ showsLevelPrec isType n term = case out term of
 showsLevel :: Bool -> Term' -> ShowS
 showsLevel level = showsLevelPrec level 0
 
+showsTerm :: Term' -> ShowS
+showsTerm = showsLevel False
+
+showsType :: Term' -> ShowS
+showsType = showsLevel True
+
 instance Eq1 f => Eq (Term f) where
   a == b = out a `eq1` out b
 

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -92,11 +92,11 @@ showsLevelPrec isType n term = case out term of
   Variable name -> shows name
   Type -> showString "Type"
   Implicit -> showString "Implicit"
-  Application a b -> showParen (n > 10) (showsPrec 10 a . showString " " . showsPrec 11 b)
+  Application a b -> showParen (n > 10) (showsLevelPrec isType 10 a . showString " " . showsLevelPrec isType 11 b)
   Lambda i t body | Set.member (Local i) (freeVariables body) -> showString "λ " . shows (Local i) . showString " : " . shows t  . showString " . " . shows body
   Lambda _ t body -> if isType
-    then shows t . showString " → " . shows body
-    else showString "λ _ : " . shows t  . showString " . " . shows body
+    then showsLevel isType t . showString " → " . showsLevel isType body
+    else showString "λ _ : " . showsLevel isType t  . showString " . " . showsLevel isType body
 
 showsLevel :: Bool -> Term' -> ShowS
 showsLevel level = showsLevelPrec level 0

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -8,7 +8,7 @@ import qualified Data.Set as Set
 data Name
   = Local Int
   | Global String
-  deriving (Show, Eq, Ord)
+  deriving (Eq, Ord)
 
 data Expression term
   = Type
@@ -99,6 +99,10 @@ showNumeral alphabet i = List.genericIndex alphabet <$> digits (List.genericLeng
 
 
 -- Instances
+
+instance Show Name where
+  show (Local i) = showNumeral ['a'..'z'] i
+  show (Global s) = s
 
 instance Eq1 Expression where
   eq1 = (==)

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -94,6 +94,8 @@ instance Show Term' where
     Lambda _ t body -> showString "λ _ : " . shows t  . showString " . " . shows body
     -- Lambda _ t body -> (shows t " → " ++ body, 0)
 
+showLevel :: Bool -> Term' -> ShowS
+showLevel = const . shows
 
 instance Eq1 f => Eq (Term f) where
   a == b = out a `eq1` out b

--- a/src/Curve.hs
+++ b/src/Curve.hs
@@ -118,11 +118,11 @@ showsLevelPrec isType n term = case out term of
   Application a b -> showParen (n > prec) (showsLevelPrec isType prec a . showString " " . showsLevelPrec isType (prec + 1) b)
     where prec = 10
   Lambda i t body | Set.member (Local i) (freeVariables body) -> if isType
-    then showString "(" . shows (Local i) . showString " : " . showsLevel True t . showString ") → " . showsLevel True body
-    else showString "λ " . shows (Local i) . showString " : " . showsLevel True t  . showString " . " . showsLevel isType body
+    then showString "(" . shows (Local i) . showString " : " . showsType t . showString ") → " . showsType body
+    else showString "λ " . shows (Local i) . showString " : " . showsType t  . showString " . " . showsLevel isType body
   Lambda _ t body -> showParen (n > 0) $ if isType
-    then showsLevelPrec True 1 t . showString " → " . showsLevel True body
-    else showString "λ _ : " . showsLevel True t  . showString " . " . showsLevel isType body
+    then showsLevelPrec True 1 t . showString " → " . showsType body
+    else showString "λ _ : " . showsType t  . showString " . " . showsLevel isType body
 
 showsLevel :: Bool -> Term' -> ShowS
 showsLevel level = showsLevelPrec level 0

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -66,5 +66,8 @@ main = hspec $ do
     prop "pretty-prints local variables alphabetically" $
       \ i -> show (Term $ Variable $ Local i) `shouldBe` showNumeral ['a'..'z'] i
 
+    it "should format the identity function appropriately" $
+      show (Term $ Lambda 1 (Term Type) $ Term $ Lambda 0 (Term (Variable (Local 1))) (Term (Variable (Local 0)))) `shouldBe` "λ b : Type . λ a : b . a"
+
   where flipUnification (Conflict a b) = Conflict b a
         flipUnification (Unification out) = Unification $ flipUnification <$> out

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -51,5 +51,8 @@ main = hspec $ do
     prop "shows non-dependent function types with an arrow operator" $
       \ a b -> showsLevel True 0 (Term $ Lambda 0 a b) "" `shouldBe` shows a " → " ++ show b
 
+    prop "parentheses left-nested non-dependent function types" $
+      \ a b c -> showsLevel True 0 (Term $ Lambda 0 (Term $ Lambda 1 a b) c) "" `shouldBe` "(" ++ showsLevel True 0 (Term $ Lambda 1 a b) ") → " ++  show c
+
   where flipUnification (Conflict a b) = Conflict b a
         flipUnification (Unification out) = Unification $ flipUnification <$> out

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -63,5 +63,8 @@ main = hspec $ do
     prop "pretty-prints Implicit as _ at any level and precedence" $
       \ isType prec -> showsLevelPrec isType prec (Term Implicit) "" `shouldBe` "_"
 
+    prop "pretty-prints local variables alphabetically" $
+      \ i -> show (Term $ Variable $ Local i) `shouldBe` showNumeral ['a'..'z'] i
+
   where flipUnification (Conflict a b) = Conflict b a
         flipUnification (Unification out) = Unification $ flipUnification <$> out

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE FlexibleInstances #-}
+import qualified Data.Set as Set
 import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck
@@ -30,6 +31,10 @@ main = hspec $ do
 
     prop "symmetry" $
       \ a b -> a `unify` b `shouldBe` flipUnification (b `unify` a)
+
+  describe "freeVariables" $ do
+    prop "variables are free in themselves" $
+      \ name -> freeVariables (Term (Variable name)) `shouldBe` Set.singleton name
 
   where flipUnification (Conflict a b) = Conflict b a
         flipUnification (Unification out) = Unification $ flipUnification <$> out

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -44,15 +44,15 @@ main = hspec $ do
     prop "lambdas are shadowing" $
       \ name t b -> freeVariables (Term (Lambda name t b)) `shouldSatisfy` Set.notMember (Local name)
 
-  describe "showsLevel" $ do
+  describe "showsLevelPrec" $ do
     prop "parenthesizes right-nested applications" $
       \ a b c -> show (Term $ Application a (Term $ Application b c)) `shouldBe` show a ++ " (" ++ showsPrec 10 (Term $ Application b c) ")"
 
     prop "shows non-dependent function types with an arrow operator" $
-      \ a b -> showsLevel True 0 (Term $ Lambda 0 a b) "" `shouldBe` shows a " → " ++ show b
+      \ a b -> showsLevelPrec True 0 (Term $ Lambda 0 a b) "" `shouldBe` shows a " → " ++ show b
 
     prop "parentheses left-nested non-dependent function types" $
-      \ a b c -> showsLevel True 0 (Term $ Lambda 0 (Term $ Lambda 1 a b) c) "" `shouldBe` "(" ++ showsLevel True 0 (Term $ Lambda 1 a b) ") → " ++  show c
+      \ a b c -> showsLevelPrec True 0 (Term $ Lambda 0 (Term $ Lambda 1 a b) c) "" `shouldBe` "(" ++ showsLevelPrec True 0 (Term $ Lambda 1 a b) ") → " ++  show c
 
   where flipUnification (Conflict a b) = Conflict b a
         flipUnification (Unification out) = Unification $ flipUnification <$> out

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -44,7 +44,7 @@ main = hspec $ do
     prop "lambdas are shadowing" $
       \ name t b -> freeVariables (Term (Lambda name t b)) `shouldSatisfy` Set.notMember (Local name)
 
-  describe "showLevel" $ do
+  describe "showsLevel" $ do
     prop "parenthesizes right-nested applications" $
       \ a b c -> show (Term $ Application a (Term $ Application b c)) `shouldBe` show a ++ " (" ++ showsPrec 10 (Term $ Application b c) ")"
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -18,6 +18,7 @@ instance Arbitrary (Term Expression) where
             : ((,) 4 . pure . Term . Variable <$> names)
 
   shrink term = case out term of
+    Application a b -> a : b : shrink a ++ shrink b
     _ -> []
 
 main :: IO ()

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -51,6 +51,9 @@ main = hspec $ do
     prop "shows non-dependent function types with an arrow operator" $
       \ a b -> showsLevelPrec True 0 (Term $ Lambda 0 a b) "" `shouldBe` showsLevelPrec True 1 a " → " ++ showsLevel True b ""
 
+    prop "shows lambda types at type level" $
+      \ a b c -> show (Term $ Lambda 1 (Term $ Lambda 0 a b) c) `shouldBe` "λ _ : " ++ showsLevelPrec True 1 a " → " ++ showsLevel True b " . " ++ show c
+
     prop "parentheses left-nested non-dependent function types" $
       \ a b c -> showsLevelPrec True 0 (Term $ Lambda 0 (Term $ Lambda 1 a b) c) "" `shouldBe` "(" ++ showsLevelPrec True 0 (Term $ Lambda 1 a b) ") → " ++ showsLevel True c ""
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -54,5 +54,8 @@ main = hspec $ do
     prop "parentheses left-nested non-dependent function types" $
       \ a b c -> showsLevelPrec True 0 (Term $ Lambda 0 (Term $ Lambda 1 a b) c) "" `shouldBe` "(" ++ showsLevelPrec True 0 (Term $ Lambda 1 a b) ") → " ++ showsLevel True c ""
 
+    prop "pretty-prints Implicit as _ at any level and precedence" $
+      \ isType prec -> showsLevelPrec isType prec (Term Implicit) "" `shouldBe` "_"
+
   where flipUnification (Conflict a b) = Conflict b a
         flipUnification (Unification out) = Unification $ flipUnification <$> out

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -49,7 +49,7 @@ main = hspec $ do
       \ a b c -> show (Term $ Application a (Term $ Application b c)) `shouldBe` showsPrec 10 a " (" ++ showsPrec 10 (Term $ Application b c) ")"
 
     prop "shows non-dependent function types with an arrow operator" $
-      \ a b -> showsLevelPrec True 0 (Term $ Lambda 0 a b) "" `shouldBe` showsLevel True a " → " ++ showsLevel True b ""
+      \ a b -> showsLevelPrec True 0 (Term $ Lambda 0 a b) "" `shouldBe` showsLevelPrec True 1 a " → " ++ showsLevel True b ""
 
     prop "parentheses left-nested non-dependent function types" $
       \ a b c -> showsLevelPrec True 0 (Term $ Lambda 0 (Term $ Lambda 1 a b) c) "" `shouldBe` "(" ++ showsLevelPrec True 0 (Term $ Lambda 1 a b) ") → " ++ showsLevel True c ""

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -39,5 +39,9 @@ main = hspec $ do
     prop "lambdas are shadowing" $
       \ name t b -> freeVariables (Term (Lambda name t b)) `shouldSatisfy` Set.notMember (Local name)
 
+  describe "show" $ do
+    prop "parenthesizes right-nested applications" $
+      \ a b c -> show (Term $ Application a (Term $ Application b c)) `shouldBe` show a ++ " " ++ show (Term $ Application b c) ++ ")"
+
   where flipUnification (Conflict a b) = Conflict b a
         flipUnification (Unification out) = Unification $ flipUnification <$> out

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -19,6 +19,7 @@ instance Arbitrary (Term Expression) where
 
   shrink term = case out term of
     Application a b -> a : b : shrink a ++ shrink b ++ (Term <$> (Application <$> a : shrink a <*> b : shrink b))
+    Lambda i t b -> t : b : shrink t ++ shrink b ++ (Term <$> (Lambda i <$> t : shrink t <*> b : shrink b))
     _ -> []
 
 main :: IO ()

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -48,5 +48,8 @@ main = hspec $ do
     prop "parenthesizes right-nested applications" $
       \ a b c -> show (Term $ Application a (Term $ Application b c)) `shouldBe` show a ++ " (" ++ showsPrec 10 (Term $ Application b c) ")"
 
+    prop "shows non-dependent function types with an arrow operator" $
+      \ a b -> showsLevel True 0 (Term $ Lambda 0 a b) "" `shouldBe` shows a " → " ++ show b
+
   where flipUnification (Conflict a b) = Conflict b a
         flipUnification (Unification out) = Unification $ flipUnification <$> out

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -17,6 +17,9 @@ instance Arbitrary (Term Expression) where
             : (1, Term <$> (Lambda (length names) <$> inScope names <*> inScope (Local (length names) : names)))
             : ((,) 4 . pure . Term . Variable <$> names)
 
+  shrink term = case out term of
+    _ -> []
+
 main :: IO ()
 main = hspec $ do
   describe "unify" $ do

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -36,5 +36,8 @@ main = hspec $ do
     prop "variables are free in themselves" $
       \ name -> freeVariables (Term (Variable name)) `shouldBe` Set.singleton name
 
+    prop "lambdas are shadowing" $
+      \ name t b -> freeVariables (Term (Lambda name t b)) `shouldSatisfy` Set.notMember (Local name)
+
   where flipUnification (Conflict a b) = Conflict b a
         flipUnification (Unification out) = Unification $ flipUnification <$> out

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -44,7 +44,7 @@ main = hspec $ do
     prop "lambdas are shadowing" $
       \ name t b -> freeVariables (Term (Lambda name t b)) `shouldSatisfy` Set.notMember (Local name)
 
-  describe "show" $ do
+  describe "showLevel" $ do
     prop "parenthesizes right-nested applications" $
       \ a b c -> show (Term $ Application a (Term $ Application b c)) `shouldBe` show a ++ " (" ++ showsPrec 10 (Term $ Application b c) ")"
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -52,7 +52,7 @@ main = hspec $ do
       \ a b -> showsLevelPrec True 0 (Term $ Lambda 0 a b) "" `shouldBe` showsLevel True a " → " ++ showsLevel True b ""
 
     prop "parentheses left-nested non-dependent function types" $
-      \ a b c -> showsLevelPrec True 0 (Term $ Lambda 0 (Term $ Lambda 1 a b) c) "" `shouldBe` "(" ++ showsLevelPrec True 0 (Term $ Lambda 1 a b) ") → " ++  show c
+      \ a b c -> showsLevelPrec True 0 (Term $ Lambda 0 (Term $ Lambda 1 a b) c) "" `shouldBe` "(" ++ showsLevelPrec True 0 (Term $ Lambda 1 a b) ") → " ++ showsLevel True c ""
 
   where flipUnification (Conflict a b) = Conflict b a
         flipUnification (Unification out) = Unification $ flipUnification <$> out

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -51,7 +51,7 @@ main = hspec $ do
     prop "shows non-dependent function types with an arrow operator" $
       \ a b -> showsLevelPrec True 0 (Term $ Lambda 0 a b) "" `shouldBe` showsLevelPrec True 1 a " → " ++ showsLevel True b ""
 
-    prop "shows lambda types at type level" $
+    prop "shows lambda’s annotations at type level" $
       \ a b c -> show (Term $ Lambda 1 (Term $ Lambda 0 a b) c) `shouldBe` "λ _ : " ++ showsLevelPrec True 1 a " → " ++ showsLevel True b " . " ++ show c
 
     prop "parentheses left-nested non-dependent function types" $

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -17,7 +17,7 @@ instance Arbitrary (Term Expression) where
             : (1, Term <$> (Lambda (length names) <$> inScope names <*> inScope (Local (length names) : names)))
             : ((,) 4 . pure . Term . Variable <$> names)
 
-  shrink term = case out term of
+  shrink term = filter (/= term) $ case out term of
     Application a b -> a : b : shrink a ++ shrink b ++ (Term <$> (Application <$> a : shrink a <*> b : shrink b))
     Lambda i t b -> t : b : shrink t ++ shrink b ++ (Term <$> (Lambda i <$> t : shrink t <*> b : shrink b))
     _ -> []

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -41,7 +41,7 @@ main = hspec $ do
 
   describe "show" $ do
     prop "parenthesizes right-nested applications" $
-      \ a b c -> show (Term $ Application a (Term $ Application b c)) `shouldBe` show a ++ " " ++ show (Term $ Application b c) ++ ")"
+      \ a b c -> show (Term $ Application a (Term $ Application b c)) `shouldBe` show a ++ " (" ++ show (Term $ Application b c) ++ ")"
 
   where flipUnification (Conflict a b) = Conflict b a
         flipUnification (Unification out) = Unification $ flipUnification <$> out

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -54,6 +54,9 @@ main = hspec $ do
     prop "shows lambda’s annotations at type level" $
       \ a b c -> show (Term $ Lambda 1 (Term $ Lambda 0 a b) c) `shouldBe` "λ _ : " ++ showsLevelPrec True 1 a " → " ++ showsLevel True b " . " ++ show c
 
+    prop "shows dependent function types with a binding arrow operator" $
+      \ a n -> showsLevel True (Term $ Lambda n a (Term $ Variable $ Local n)) "" `shouldBe` "(" ++ shows n " : " ++ showsLevel True a ") → " ++ showsLevel True (Term $ Variable $ Local n) ""
+
     prop "parentheses left-nested non-dependent function types" $
       \ a b c -> showsLevelPrec True 0 (Term $ Lambda 0 (Term $ Lambda 1 a b) c) "" `shouldBe` "(" ++ showsLevelPrec True 0 (Term $ Lambda 1 a b) ") → " ++ showsLevel True c ""
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -46,7 +46,7 @@ main = hspec $ do
 
   describe "showsLevelPrec" $ do
     prop "parenthesizes right-nested applications" $
-      \ a b c -> show (Term $ Application a (Term $ Application b c)) `shouldBe` show a ++ " (" ++ showsPrec 10 (Term $ Application b c) ")"
+      \ a b c -> show (Term $ Application a (Term $ Application b c)) `shouldBe` showsPrec 10 a " (" ++ showsPrec 10 (Term $ Application b c) ")"
 
     prop "shows non-dependent function types with an arrow operator" $
       \ a b -> showsLevelPrec True 0 (Term $ Lambda 0 a b) "" `shouldBe` showsLevel True a " → " ++ showsLevel True b ""

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -46,7 +46,7 @@ main = hspec $ do
 
   describe "show" $ do
     prop "parenthesizes right-nested applications" $
-      \ a b c -> show (Term $ Application a (Term $ Application b c)) `shouldBe` show a ++ " (" ++ show (Term $ Application b c) ++ ")"
+      \ a b c -> show (Term $ Application a (Term $ Application b c)) `shouldBe` show a ++ " (" ++ showsPrec 10 (Term $ Application b c) ")"
 
   where flipUnification (Conflict a b) = Conflict b a
         flipUnification (Unification out) = Unification $ flipUnification <$> out

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -49,7 +49,7 @@ main = hspec $ do
       \ a b c -> show (Term $ Application a (Term $ Application b c)) `shouldBe` show a ++ " (" ++ showsPrec 10 (Term $ Application b c) ")"
 
     prop "shows non-dependent function types with an arrow operator" $
-      \ a b -> showsLevelPrec True 0 (Term $ Lambda 0 a b) "" `shouldBe` shows a " → " ++ show b
+      \ a b -> showsLevelPrec True 0 (Term $ Lambda 0 a b) "" `shouldBe` showsLevel True a " → " ++ showsLevel True b ""
 
     prop "parentheses left-nested non-dependent function types" $
       \ a b c -> showsLevelPrec True 0 (Term $ Lambda 0 (Term $ Lambda 1 a b) c) "" `shouldBe` "(" ++ showsLevelPrec True 0 (Term $ Lambda 1 a b) ") → " ++  show c

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -49,16 +49,16 @@ main = hspec $ do
       \ a b c -> show (Term $ Application a (Term $ Application b c)) `shouldBe` showsPrec 10 a " (" ++ showsPrec 10 (Term $ Application b c) ")"
 
     prop "shows non-dependent function types with an arrow operator" $
-      \ a b -> showsLevelPrec True 0 (Term $ Lambda 0 a b) "" `shouldBe` showsLevelPrec True 1 a " → " ++ showsLevel True b ""
+      \ a b -> showsLevelPrec True 0 (Term $ Lambda 0 a b) "" `shouldBe` showsLevelPrec True 1 a " → " ++ showsType b ""
 
     prop "shows lambda’s annotations at type level" $
-      \ a b c -> show (Term $ Lambda 1 (Term $ Lambda 0 a b) c) `shouldBe` "λ _ : " ++ showsLevelPrec True 1 a " → " ++ showsLevel True b " . " ++ show c
+      \ a b c -> show (Term $ Lambda 1 (Term $ Lambda 0 a b) c) `shouldBe` "λ _ : " ++ showsLevelPrec True 1 a " → " ++ showsType b " . " ++ show c
 
     prop "shows dependent function types with a binding arrow operator" $
-      \ a n -> showsLevel True (Term $ Lambda n a (Term $ Variable $ Local n)) "" `shouldBe` "(" ++ shows (Local n) " : " ++ showsLevel True a ") → " ++ showsLevel True (Term $ Variable $ Local n) ""
+      \ a n -> showsType (Term $ Lambda n a (Term $ Variable $ Local n)) "" `shouldBe` "(" ++ shows (Local n) " : " ++ showsType a ") → " ++ showsType (Term $ Variable $ Local n) ""
 
     prop "parentheses left-nested non-dependent function types" $
-      \ a b c -> showsLevelPrec True 0 (Term $ Lambda 0 (Term $ Lambda 1 a b) c) "" `shouldBe` "(" ++ showsLevelPrec True 0 (Term $ Lambda 1 a b) ") → " ++ showsLevel True c ""
+      \ a b c -> showsLevelPrec True 0 (Term $ Lambda 0 (Term $ Lambda 1 a b) c) "" `shouldBe` "(" ++ showsLevelPrec True 0 (Term $ Lambda 1 a b) ") → " ++ showsType c ""
 
     prop "pretty-prints Implicit as _ at any level and precedence" $
       \ isType prec -> showsLevelPrec isType prec (Term Implicit) "" `shouldBe` "_"

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -55,7 +55,7 @@ main = hspec $ do
       \ a b c -> show (Term $ Lambda 1 (Term $ Lambda 0 a b) c) `shouldBe` "λ _ : " ++ showsLevelPrec True 1 a " → " ++ showsLevel True b " . " ++ show c
 
     prop "shows dependent function types with a binding arrow operator" $
-      \ a n -> showsLevel True (Term $ Lambda n a (Term $ Variable $ Local n)) "" `shouldBe` "(" ++ shows n " : " ++ showsLevel True a ") → " ++ showsLevel True (Term $ Variable $ Local n) ""
+      \ a n -> showsLevel True (Term $ Lambda n a (Term $ Variable $ Local n)) "" `shouldBe` "(" ++ shows (Local n) " : " ++ showsLevel True a ") → " ++ showsLevel True (Term $ Variable $ Local n) ""
 
     prop "parentheses left-nested non-dependent function types" $
       \ a b c -> showsLevelPrec True 0 (Term $ Lambda 0 (Term $ Lambda 1 a b) c) "" `shouldBe` "(" ++ showsLevelPrec True 0 (Term $ Lambda 1 a b) ") → " ++ showsLevel True c ""

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -18,7 +18,7 @@ instance Arbitrary (Term Expression) where
             : ((,) 4 . pure . Term . Variable <$> names)
 
   shrink term = case out term of
-    Application a b -> a : b : shrink a ++ shrink b
+    Application a b -> a : b : shrink a ++ shrink b ++ (Term <$> (Application <$> a : shrink a <*> b : shrink b))
     _ -> []
 
 main :: IO ()


### PR DESCRIPTION
- [x] Nice formatting of terms using `showsPrec`.
- [x] Format contextually (types vs. non-types).
- [x] Format pi types in context.
- [x] Increase the level for lambda types.
- [x] Format local variables alphabetically.
